### PR TITLE
libpng 1.6.55

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libpng" %}
-{% set version = "1.6.54" %}
+{% set version = "1.6.55" %}
 {% set short_version = version.split('.')[0] ~ version.split('.')[1] %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://download.sourceforge.net/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 472db714567391842e410090df5a37e0f5b2ec67148a3007678b0482d2ba5219
+  sha256: 4b0abab6d219e95690ebe4db7fc9aa95f4006c83baaa022373c0c8442271283d
   patches:
     - 0001-Include-pkg-config-files-in-the-Windows-packages-too.patch
     - 0002-Ensure-that-lm-is-not-included-in-Windows-pkg-config.patch


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-12755](https://anaconda.atlassian.net/browse/PKG-12755)
- [Upstream repository](https://sourceforge.net/p/libpng/code/ci/libpng16/tree/)
- [Upstream changelog/diff](https://sourceforge.net/p/libpng/code/ci/libpng16/tree/CHANGES)

### Explanation of changes:

- Bump version number
- impacted by [CVE-2026-25646](https://nvd.nist.gov/vuln/detail/CVE-2026-25646) with a HIGH score


[PKG-12755]: https://anaconda.atlassian.net/browse/PKG-12755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ