### PR TITLE
libpng-1.6.56

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ requirements:
 test:
   requires:
     - {{ compiler('c') }}  # [unix]
+    - zlib {{ zlib }}
   files:
     - test_libpng_write.c
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libpng" %}
-{% set version = "1.6.55" %}
+{% set version = "1.6.56" %}
 {% set short_version = version.split('.')[0] ~ version.split('.')[1] %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://download.sourceforge.net/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4b0abab6d219e95690ebe4db7fc9aa95f4006c83baaa022373c0c8442271283d
+  sha256: 8f91e941a07fb1069ebb3855278f82a849e6af14ca05821e14ec3d5348697ea5
   patches:
     - 0001-Include-pkg-config-files-in-the-Windows-packages-too.patch
     - 0002-Ensure-that-lm-is-not-included-in-Windows-pkg-config.patch
@@ -33,6 +33,10 @@ requirements:
     - zlib {{ zlib }}
 
 test:
+  requires:
+    - {{ compiler('c') }}  # [unix]
+  files:
+    - test_libpng_write.c
   commands:
     - test -f ${PREFIX}/lib/libpng${SHLIB_EXT}                          # [unix]
     - test -f ${PREFIX}/lib/libpng{{ short_version }}${SHLIB_EXT}       # [unix]
@@ -41,6 +45,8 @@ test:
     - test -f ${PREFIX}/include/libpng{{ short_version }}/pnglibconf.h  # [unix]
     - libpng-config --version  # [unix]
     - echo "tests done during build ..."  # [win]
+    - ${CC} test_libpng_write.c -I${PREFIX}/include -L${PREFIX}/lib -lpng -lz -Wl,-rpath,${PREFIX}/lib -o test_libpng_write  # [unix]
+    - ./test_libpng_write  # [unix]
 
 about:
   home: https://www.libpng.org/pub/png/libpng.html
@@ -52,7 +58,7 @@ about:
     libpng is the official PNG reference library. It supports almost all PNG
     features, is extensible, and has been extensively tested for over 30 years.
   doc_url: https://www.libpng.org/pub/png/libpng.html
-  dev_url: https://sourceforge.net/p/libpng/code/ci/libpng16/tree/
+  dev_url: https://sourceforge.net/p/libpng/code/ci/libpng16/tree
 
 extra:
   recipe-maintainers:

--- a/recipe/test_libpng_write.c
+++ b/recipe/test_libpng_write.c
@@ -1,3 +1,12 @@
+/*
+ * Basic libpng functional test.
+ *
+ * This test verifies that libpng can be linked and used for a minimal
+ * write workflow. It creates a 1x1 RGB PNG image, writes it to disk,
+ * reopens the file, and checks the PNG signature to confirm that the
+ * output is a valid PNG file.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <png.h>

--- a/recipe/test_libpng_write.c
+++ b/recipe/test_libpng_write.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <png.h>
+
+int main(void) {
+    const char *filename = "test.png";
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        fprintf(stderr, "failed to open %s for writing\n", filename);
+        return 1;
+    }
+
+    png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    if (!png_ptr) {
+        fprintf(stderr, "png_create_write_struct failed\n");
+        fclose(fp);
+        return 1;
+    }
+
+    png_infop info_ptr = png_create_info_struct(png_ptr);
+    if (!info_ptr) {
+        fprintf(stderr, "png_create_info_struct failed\n");
+        png_destroy_write_struct(&png_ptr, NULL);
+        fclose(fp);
+        return 1;
+    }
+
+    if (setjmp(png_jmpbuf(png_ptr))) {
+        fprintf(stderr, "libpng write error\n");
+        png_destroy_write_struct(&png_ptr, &info_ptr);
+        fclose(fp);
+        remove(filename);
+        return 1;
+    }
+
+    png_init_io(png_ptr, fp);
+
+    png_set_IHDR(
+        png_ptr,
+        info_ptr,
+        1,
+        1,
+        8,
+        PNG_COLOR_TYPE_RGB,
+        PNG_INTERLACE_NONE,
+        PNG_COMPRESSION_TYPE_BASE,
+        PNG_FILTER_TYPE_BASE
+    );
+
+    png_write_info(png_ptr, info_ptr);
+
+    png_byte row[3] = {255, 0, 0};
+    png_write_row(png_ptr, row);
+    png_write_end(png_ptr, NULL);
+
+    png_destroy_write_struct(&png_ptr, &info_ptr);
+    fclose(fp);
+
+    fp = fopen(filename, "rb");
+    if (!fp) {
+        fprintf(stderr, "failed to reopen %s\n", filename);
+        return 1;
+    }
+
+    unsigned char sig[8];
+    if (fread(sig, 1, sizeof(sig), fp) != sizeof(sig)) {
+        fprintf(stderr, "failed to read PNG signature\n");
+        fclose(fp);
+        return 1;
+    }
+    fclose(fp);
+
+    if (png_sig_cmp(sig, 0, sizeof(sig)) != 0) {
+        fprintf(stderr, "output file is not a valid PNG\n");
+        return 1;
+    }
+
+    printf("libpng OK: wrote valid 1x1 PNG to %s\n", filename);
+    return 0;
+}


### PR DESCRIPTION
libpng-1.6.56

**Destination channel:** Defaults

### Links

- [JIRA](https://anaconda.atlassian.net/browse/PKG-13258)
- [Upstream repository](https://sourceforge.net/p/libpng/code/ci/libpng16/tree/)
- [Upstream changelog/diff](https://sourceforge.net/p/libpng/code/ci/libpng16/tree/CHANGES)

### Explanation of changes:
- version bump
- Two high-severity vulnerabilities fixed: CVE-2026-33416, CVE-2026-33636
- added test_libpng_write.c

